### PR TITLE
adding preempted to printed status

### DIFF
--- a/cmd/beaker/print.go
+++ b/cmd/beaker/print.go
@@ -538,7 +538,7 @@ func jobStatus(state api.JobStatus) string {
 	case state.Scheduled != nil:
 		return "starting"
 	case state.Canceled != nil && state.CanceledFor == "preempted":
-		return "preepted"
+		return "preempted"
 	default:
 		return "pending"
 	}

--- a/cmd/beaker/print.go
+++ b/cmd/beaker/print.go
@@ -537,6 +537,8 @@ func jobStatus(state api.JobStatus) string {
 		return "running"
 	case state.Scheduled != nil:
 		return "starting"
+	case state.Canceled != nil && state.CanceledFor == "preempted":
+		return "preepted"
 	default:
 		return "pending"
 	}

--- a/cmd/beaker/print.go
+++ b/cmd/beaker/print.go
@@ -537,8 +537,15 @@ func jobStatus(state api.JobStatus) string {
 		return "running"
 	case state.Scheduled != nil:
 		return "starting"
-	case state.Canceled != nil && state.CanceledFor == "preempted":
-		return "preempted"
+	case state.Canceled != nil:
+		if state.CanceledFor == "system" {
+			return "preempted by system"
+		}
+		if state.CanceledFor == "user" {
+			return "preempted by user"
+		}
+		return "canceled"
+
 	default:
 		return "pending"
 	}


### PR DESCRIPTION
https://github.com/allenai/beaker-service/issues/1988

This is the change for #1988 where `beaker experiment get` needs to be intuitive for preemption. To do this, when the status of each job in an experiment is created, I added logic to check for preemption - if the job is canceled and canceledFor is set to "preempted."

Earlier today we discussed a CanceledCode and CanceledMessage. The end result of that would affect this code and other spaces. Since this is what's currently implemented, it's what I'll base my work off of. I'd like to have a brief chat with @aimichal and @codeviking to decide how to move forward.